### PR TITLE
attribute readers for ConvNd

### DIFF
--- a/lib/torch/nn/convnd.rb
+++ b/lib/torch/nn/convnd.rb
@@ -1,6 +1,8 @@
 module Torch
   module NN
     class ConvNd < Module
+      attr_reader :in_channels, :out_channels, :kernel_size, :stride, :padding, :dilation, :transposed, :output_paddding, :groups, :padding_mode
+      
       def initialize(in_channels, out_channels, kernel_size, stride, padding, dilation, transposed, output_padding, groups, bias, padding_mode)
         super()
         raise ArgumentError, "in_channels must be divisible by groups" if in_channels % groups != 0


### PR DESCRIPTION
It is often useful to access convolutional layer attributes, e.g. for output shapes precalculation.